### PR TITLE
(fix): border was not appearing before

### DIFF
--- a/apps/portfolio/src/routes/+layout.svelte
+++ b/apps/portfolio/src/routes/+layout.svelte
@@ -11,7 +11,6 @@
 	import type { LayoutServerData } from './$types';
 	import Border from './Border.svelte';
 	import PageTransition from './PageTransition.svelte';
-	import CursorTracker from '@/components/CursorTracker.svelte';
 
 	if (browser) {
 		beforeNavigate(() => posthog.capture('$pageleave'));
@@ -29,7 +28,6 @@
 <SEO {...data.SEO} />
 <Socials />
 <PageTransition />
-<CursorTracker />
 <div class="relative overflow-hidden">
 	<Border>
 		<main class="no-scrollbar relative flex flex-col p-10 sm:p-16">


### PR DESCRIPTION
This pull request makes a small change to the `+layout.svelte` file by removing the `CursorTracker` component from the layout. This simplifies the UI by no longer rendering the cursor tracking functionality. 

- Removed the import and usage of the `CursorTracker` component from `+layout.svelte`. [[1]](diffhunk://#diff-42baac73adfaa21ec300f9963f23d7dec651acb1179471e8dff4e467522d7768L14) [[2]](diffhunk://#diff-42baac73adfaa21ec300f9963f23d7dec651acb1179471e8dff4e467522d7768L32)