### PR TITLE
(fix): projects were not showing before

### DIFF
--- a/apps/portfolio/src/lib/getProject.ts
+++ b/apps/portfolio/src/lib/getProject.ts
@@ -1,3 +1,4 @@
+import type { ComponentType } from 'svelte';
 import { z } from 'zod';
 
 const technologySchema = z.object({
@@ -52,7 +53,7 @@ export type Project = {
   }[];
   featured: boolean;
   order: number;
-  content: string;
+  content: ComponentType;
 };
 
 export async function getProject(slug: string): Promise<Project | null> {
@@ -68,7 +69,7 @@ export async function getProject(slug: string): Promise<Project | null> {
     // Transform the data to match the expected structure
     const transformedProject: Project = {
       ...project.data.metadata,
-      content: project.data.default?.render?.().html || '',
+      content: project.data.default,
       technologies: project.data.metadata.technologies.map(tech => ({ title: tech })),
       images: project.data.metadata.images.map(img => ({
         asset: {
@@ -112,7 +113,7 @@ export async function getAllProjects(): Promise<Project[]> {
       keyFeatures: project.metadata.keyFeatures,
       featured: project.metadata.featured,
       order: project.metadata.order,
-      content: project.default?.render?.().html || '',
+      content: project.default,
       technologies: project.metadata.technologies.map(tech => ({ title: tech })),
       images: project.metadata.images.map(img => ({
         asset: {

--- a/apps/portfolio/src/routes/projects/[slug]/+page.server.ts
+++ b/apps/portfolio/src/routes/projects/[slug]/+page.server.ts
@@ -1,39 +1,10 @@
 import { getTotalLikesByPage } from '@/lib/db/methods';
-import { getAllProjects, getProject } from '@/lib/getProject';
-import { error } from '@sveltejs/kit';
-import type { EntryGenerator, PageServerLoad } from './$types';
+import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ params }) => {
 	const { slug } = params;
 
-	const [project, allProjects] = await Promise.all([
-		getProject(slug),
-		getAllProjects(),
-	]);
-
-	if (!project) {
-		throw error(404, 'Project not found');
-	}
-
-	const projectIndex = allProjects.findIndex((p) => p.slug === slug);
-	const nextProject = allProjects[projectIndex + 1] ?? null;
-	const prevProject = allProjects[projectIndex - 1] ?? null;
-
 	return {
-		project,
-		nextProject: nextProject ? { title: nextProject.title, slug: nextProject.slug } : null,
-		prevProject: prevProject ? { title: prevProject.title, slug: prevProject.slug } : null,
-		slug,
 		likes: await getTotalLikesByPage(slug),
 	};
 };
-
-export const entries: EntryGenerator = async () => {
-	const allProjects = await getAllProjects();
-	const slugs = allProjects.map((p) => p.slug);
-
-	return slugs.map((slug) => ({ slug }));
-};
-
-export const prerender = true;
-export const ssr = true;

--- a/apps/portfolio/src/routes/projects/[slug]/+page.svelte
+++ b/apps/portfolio/src/routes/projects/[slug]/+page.svelte
@@ -66,7 +66,7 @@
 <section class="prose text-foreground prose-bold:text-foreground! w-full max-w-full text-left leading-loose">
 	{#key project.title}
 		{#if project.content}
-			{@html project.content}
+			<svelte:component this={project.content} />
 		{:else if project.description}
 			<p>
 				{project.description}

--- a/apps/portfolio/src/routes/projects/[slug]/+page.ts
+++ b/apps/portfolio/src/routes/projects/[slug]/+page.ts
@@ -1,0 +1,38 @@
+import { getProject, getAllProjects } from '@/lib/getProject';
+import { error } from '@sveltejs/kit';
+import type { EntryGenerator, PageLoad } from './$types';
+
+export const load: PageLoad = async ({ params, data }) => {
+	const { slug } = params;
+
+	const [project, allProjects] = await Promise.all([
+		getProject(slug),
+		getAllProjects(),
+	]);
+
+	if (!project) {
+		throw error(404, 'Project not found');
+	}
+
+	const projectIndex = allProjects.findIndex((p) => p.slug === slug);
+	const nextProject = allProjects[projectIndex + 1] ?? null;
+	const prevProject = allProjects[projectIndex - 1] ?? null;
+
+	return {
+		project,
+		nextProject: nextProject ? { title: nextProject.title, slug: nextProject.slug } : null,
+		prevProject: prevProject ? { title: prevProject.title, slug: prevProject.slug } : null,
+		slug,
+		likes: data.likes,
+	};
+};
+
+export const entries: EntryGenerator = async () => {
+	const allProjects = await getAllProjects();
+	const slugs = allProjects.map((p) => p.slug);
+
+	return slugs.map((slug) => ({ slug }));
+};
+
+export const prerender = true;
+export const ssr = true;


### PR DESCRIPTION
This pull request updates how project content is handled and rendered in the portfolio app, moving from storing raw HTML strings to using Svelte components for project content. It also reorganizes the project page server/client logic to better align with SvelteKit's routing conventions.

**Project Content Handling:**

* Changed the `content` field in the `Project` type from a `string` (HTML) to a `ComponentType`, allowing project content to be rendered as a Svelte component instead of raw HTML. (`apps/portfolio/src/lib/getProject.ts`, [apps/portfolio/src/lib/getProject.tsL55-R56](diffhunk://#diff-500e27a2ae8a3b527efbf1f1c0eaff49972de897a3f18bd995566dc0eb9f7f59L55-R56))
* Updated the transformation logic in `getProject` and `getAllProjects` to assign the Svelte component directly to the `content` field, rather than rendering to HTML. (`apps/portfolio/src/lib/getProject.ts`, [[1]](diffhunk://#diff-500e27a2ae8a3b527efbf1f1c0eaff49972de897a3f18bd995566dc0eb9f7f59L71-R72) [[2]](diffhunk://#diff-500e27a2ae8a3b527efbf1f1c0eaff49972de897a3f18bd995566dc0eb9f7f59L115-R116)
* Modified the project page to render the `content` field using `<svelte:component>`, enabling dynamic Svelte component rendering. (`apps/portfolio/src/routes/projects/[slug]/+page.svelte`, [apps/portfolio/src/routes/projects/[slug]/+page.svelteL69-R69](diffhunk://#diff-48664ecf7f97a2b6d88a690629f3db8a97edb2405c80aba76144d67279b9104cL69-R69))

**Routing and Data Loading Refactor:**

* Moved project loading, navigation (next/previous project), and entry generation logic from the server load file (`+page.server.ts`) to the client load file (`+page.ts`), aligning with SvelteKit's recommended data loading patterns. (`apps/portfolio/src/routes/projects/[slug]/+page.server.ts`, [apps/portfolio/src/routes/projects/[slug]/+page.server.tsL2-L39](diffhunk://#diff-6180016df5e8a998815e164f70795b65daeca10b8e138afbaac9025e8bc7e797L2-L39); `apps/portfolio/src/routes/projects/[slug]/+page.ts`, [apps/portfolio/src/routes/projects/[slug]/+page.tsR1-R38](diffhunk://#diff-c0d1d913f586fa6a93439a44c2894c06b52acb9c10d6b2f02626bee3573bb56cR1-R38))
* Cleaned up the server load file to only fetch likes, delegating all project-related data fetching to the new client load file. (`apps/portfolio/src/routes/projects/[slug]/+page.server.ts`, [apps/portfolio/src/routes/projects/[slug]/+page.server.tsL2-L39](diffhunk://#diff-6180016df5e8a998815e164f70795b65daeca10b8e138afbaac9025e8bc7e797L2-L39))