### PR TITLE
(chore): personalize to me

### DIFF
--- a/apps/portfolio/src/components/Footer.svelte
+++ b/apps/portfolio/src/components/Footer.svelte
@@ -11,7 +11,7 @@
 <footer class="flex w-full flex-col items-center justify-center gap-8 py-12 text-sm">
 	<div class="flex items-center justify-center gap-2">
 		<a
-			href="https://www.linkedin.com/in/kyrre-gjerstad/"
+			href="https://www.linkedin.com/in/mohith-n/"
 			target="_blank"
 			onclick={() => posthog.capture('social_link_click', { target: 'linkedin', location: 'footer' })}
 		>
@@ -19,7 +19,7 @@
 			<LinkedInAnimated />
 		</a>
 		<a
-			href="https://github.com/kyrregjerstad"
+			href="https://github.com/mohithbuilds"
 			target="_blank"
 			onclick={() => posthog.capture('social_link_click', { target: 'github', location: 'footer' })}
 		>
@@ -27,7 +27,7 @@
 			<GitHubIconAnimated size={4.5} />
 		</a>
 		<a
-			href="https://bsky.app/profile/kyrre.dev"
+			href="mailto:mohith.n2022@gmail.com"
 			target="_blank"
 			class="transition-transform hover:scale-110"
 			onclick={() => posthog.capture('social_link_click', { target: 'bsky', location: 'footer' })}
@@ -37,11 +37,11 @@
 		</a>
 	</div>
 	<div class="flex items-center justify-center gap-2">
-		<a class="hover:underline" href="/about/kyrregjerstad">About</a>
+		<a class="hover:underline" href="/about/mohithnagendra">About</a>
 		<a class="hover:underline" href="/blog">Blog</a>
 	</div>
 
 	<p class="">
-		Made with <HeartIcon class="fill-foreground inline size-4 -translate-y-px" /> by Kyrre Gjerstad
+		Made with <HeartIcon class="fill-foreground inline size-4 -translate-y-px" /> by Mohith Nagendra
 	</p>
 </footer>

--- a/apps/portfolio/src/components/Socials.svelte
+++ b/apps/portfolio/src/components/Socials.svelte
@@ -7,24 +7,24 @@
 </script>
 
 {#if !isBlogPost}
-	<meta property="og:site_name" content="Kyrre Gjerstad" />
+	<meta property="og:site_name" content="Mohith Nagendra" />
 	<meta property="og:url" content="https://kyrre.dev" />
 	<meta property="og:type" content="website" />
-	<meta property="og:title" content="Kyrre Gjerstad - Full-stack developer" />
+	<meta property="og:title" content="Mohith Nagendra - Full-stack developer" />
 	<meta property="og:image" content="https://kyrre.dev/images/og-kyrre-gjerstad.jpg" />
 	<meta
 		property="og:description"
-		content="Portfolio of Kyrre Gjerstad, a full-stack developer specializing in NextJS and SvelteKit."
+		content="Portfolio of Mohith Nagendra, a full-stack developer specializing in NextJS and SvelteKit."
 	/>
 	<meta property="og:image:width" content="1200" />
 	<meta property="og:image:height" content="630" />
 	<meta name="twitter:card" content="summary_large_image" />
 	<meta name="twitter:site" content="@kyrregjerstad" />
 	<meta name="twitter:creator" content="@kyrregjerstad" />
-	<meta name="twitter:title" content="Kyrre Gjerstad - Full-stack developer" />
+	<meta name="twitter:title" content="Mohith Nagendra - Full-stack developer" />
 	<meta
 		name="twitter:description"
-		content="Portfolio of Kyrre Gjerstad, a full-stack developer specializing in NextJS and SvelteKit."
+		content="Portfolio of Mohith Nagendra, a full-stack developer specializing in NextJS and SvelteKit."
 	/>
 	<meta name="twitter:image" content="https://kyrre.dev/images/og-kyrre-gjerstad.jpg" />
 {/if}

--- a/apps/portfolio/src/lib/getPost.ts
+++ b/apps/portfolio/src/lib/getPost.ts
@@ -9,7 +9,7 @@ const postSchema = z.object({
 		published: z.boolean().default(false),
 		publishedAt: z.string(),
 		categories: z.array(z.string()).default([]),
-		author: z.string().default('Kyrre Gjerstad'),
+		author: z.string().default('Mohith Nagendra'),
 		description: z.string().optional(),
 		seoTitle: z.string().optional(),
 		seoDescription: z.string().optional(),

--- a/apps/portfolio/src/posts/the-pragmatic-guide-to-playwright-testing.md
+++ b/apps/portfolio/src/posts/the-pragmatic-guide-to-playwright-testing.md
@@ -6,7 +6,7 @@ layout: blog
 published: true
 publishedAt: '2025-05-16'
 categories: ['testing', 'automation', 'web development', 'quality assurance']
-author: 'Kyrre Gjerstad'
+author: 'Mohith Nagendra'
 description: 'A comprehensive guide to writing effective and maintainable Playwright tests, covering best practices, patterns, and real-world examples.'
 seoTitle: 'The Pragmatic Guide to Playwright Testing: Best Practices & Patterns'
 seoDescription: 'Learn how to write effective and maintainable Playwright tests with this comprehensive guide. Covers best practices, patterns, and real-world examples from production environments.'

--- a/apps/portfolio/src/routes/+layout.server.ts
+++ b/apps/portfolio/src/routes/+layout.server.ts
@@ -5,7 +5,7 @@ export const load: LayoutServerLoad = async ({ locals }) => {
 	const { firstVisit } = locals;
 
 	const SEO = {
-		title: 'Kyrre Gjerstad | Fullstack Typescript Developer',
+		title: 'Mohith Nagendra | Fullstack Typescript Developer',
 		description:
 			'Passionate about creating visually appealing and functional web applications using SvelteKit and NextJS. Explore my portfolio and discover my work in building clean, efficient, and user-friendly digital experiences.',
 		keywords: [
@@ -19,21 +19,21 @@ export const load: LayoutServerLoad = async ({ locals }) => {
 			'web applications',
 			'portfolio',
 		],
-		author: 'Kyrre Gjerstad',
+		author: 'Mohith Nagendra',
 
 		openGraph: {
 			url: 'https://kyrre.dev',
-			title: 'Kyrre Gjerstad | Fullstack Typescript Developer',
+			title: 'Mohith Nagendra | Fullstack Typescript Developer',
 			description:
-				'Explore the portfolio of Kyrre Gjerstad, a fullstack developer specializing in SvelteKit and NextJS.',
+				'Explore the portfolio of Mohith Nagendra, a fullstack developer specializing in SvelteKit and NextJS.',
 			image: 'https://kyrre.dev/images/og-kyrre-gjerstad.jpg',
 		},
 
 		twitter: {
 			url: 'https://kyrre.dev',
-			title: 'Kyrre Gjerstad | Fullstack Typescript Developer',
+			title: 'Mohith Nagendra | Fullstack Typescript Developer',
 			description:
-				'Discover the work of Kyrre Gjerstad, a fullstack developer passionate about creating functional and visually appealing web applications using SvelteKit and NextJS.',
+				'Discover the work of Mohith Nagendra, a fullstack developer passionate about creating functional and visually appealing web applications using SvelteKit and NextJS.',
 			image: 'https://kyrre.dev/images/og-kyrre-gjerstad.jpg',
 			card: 'summary_large_image',
 			site: '@kyrregjerstad',

--- a/apps/portfolio/src/routes/+layout.ts
+++ b/apps/portfolio/src/routes/+layout.ts
@@ -1,7 +1,7 @@
 export const load = async () => {
 	return {
 		SEO: {
-			title: 'Kyrre Gjerstad | Fullstack Typescript Developer',
+			title: 'Mohith Nagendra | Fullstack Typescript Developer',
 			description:
 				'Passionate about creating visually appealing and functional web applications using SvelteKit and NextJS. Explore my portfolio and discover my work in building clean, efficient, and user-friendly digital experiences.',
 			keywords: [
@@ -15,21 +15,21 @@ export const load = async () => {
 				'web applications',
 				'portfolio',
 			],
-			author: 'Kyrre Gjerstad',
+			author: 'Mohith Nagendra',
 
 			openGraph: {
 				url: 'https://kyrre.dev',
-				title: 'Kyrre Gjerstad | Fullstack Typescript Developer',
+				title: 'Mohith Nagendra | Fullstack Typescript Developer',
 				description:
-					'Explore the portfolio of Kyrre Gjerstad, a fullstack developer specializing in SvelteKit and NextJS.',
+					'Explore the portfolio of Mohith Nagendra, a fullstack developer specializing in SvelteKit and NextJS.',
 				image: 'https://kyrre.dev/images/og-kyrre-gjerstad.jpg',
 			},
 
 			twitter: {
 				url: 'https://kyrre.dev',
-				title: 'Kyrre Gjerstad | Fullstack Typescript Developer',
+				title: 'Mohith Nagendra | Fullstack Typescript Developer',
 				description:
-					'Discover the work of Kyrre Gjerstad, a fullstack developer passionate about creating functional and visually appealing web applications using SvelteKit and NextJS.',
+					'Discover the work of Mohith Nagendra, a fullstack developer passionate about creating functional and visually appealing web applications using SvelteKit and NextJS.',
 				image: 'https://kyrre.dev/images/og-kyrre-gjerstad.jpg',
 				card: 'summary_large_image',
 				site: '@kyrregjerstad',

--- a/apps/portfolio/src/routes/HeroSection.svelte
+++ b/apps/portfolio/src/routes/HeroSection.svelte
@@ -19,7 +19,7 @@
 				<h1
 					class="flex items-end gap-2 text-pretty break-words text-4xl font-extrabold leading-none tracking-tight md:text-5xl lg:text-6xl"
 				>
-					Hei, I'm Kyrre!
+					Hi, I'm Mohith!
 				</h1>
 				<span class="flex items-center gap-1 text-pretty text-sm font-normal">
 					<MapPin size={12} />
@@ -42,7 +42,7 @@
 
 			<div class="flex items-center gap-3">
 				<a
-					href="https://github.com/kyrregjerstad"
+					href="https://github.com/mohithbuilds"
 					target="_blank"
 					class="transition-transform hover:scale-110"
 					onclick={() => posthog.capture('social_link_click', { target: 'github', location: 'hero' })}
@@ -51,7 +51,7 @@
 					<GitHubIconAnimated size={2.5} />
 				</a>
 				<a
-					href="https://www.linkedin.com/in/kyrre-gjerstad/"
+					href="https://www.linkedin.com/in/mohith-n/"
 					target="_blank"
 					class="transition-transform hover:scale-110"
 					onclick={() => posthog.capture('social_link_click', { target: 'linkedin', location: 'hero' })}
@@ -60,7 +60,7 @@
 					<LinkedInAnimated size={2.5} />
 				</a>
 				<a
-					href="https://bsky.app/profile/kyrre.dev"
+					href="mailto:mohith.n2022@gmail.com"
 					target="_blank"
 					class="transition-transform hover:scale-110"
 					onclick={() => posthog.capture('social_link_click', { target: 'bsky', location: 'hero' })}

--- a/apps/portfolio/src/routes/about/kyrregjerstad/+page.svelte
+++ b/apps/portfolio/src/routes/about/kyrregjerstad/+page.svelte
@@ -2,10 +2,10 @@
 </script>
 
 <svelte:head>
-	<title>About Kyrre Gjerstad - Full Stack Developer in Berlin</title>
+	<title>About Mohith Nagendra - Full Stack Developer</title>
 	<meta
 		name="description"
-		content="Kyrre Gjerstad is a Full Stack Developer based in Berlin, specializing in TypeScript, Next.js, and building performant web applications. Learn more about his experience and approach to web development."
+		content="Mohith Nagendra is a Full Stack Developer based in Berlin, specializing in TypeScript, Next.js, and building performant web applications. Learn more about his experience and approach to web development."
 	/>
 </svelte:head>
 
@@ -15,22 +15,22 @@
 			<div class="ring-border mb-6 h-48 w-48 overflow-hidden rounded-full ring-2">
 				<img
 					src="/images/kyrre-gjerstad-profile-1.webp"
-					alt="Kyrre Gjerstad"
+					alt="Mohith Nagendra"
 					class="h-full w-full object-cover"
 					width="192"
 					height="192"
 				/>
 			</div>
 		</div>
-		<h1 class="mb-4 text-center text-4xl font-bold">About Kyrre Gjerstad</h1>
-		<p class="text-muted-foreground text-center text-lg">Full Stack Developer based in Berlin</p>
+		<h1 class="mb-4 text-center text-4xl font-bold">About Mohith Nagendra</h1>
+		<p class="text-muted-foreground text-center text-lg">Full Stack Developer</p>
 	</header>
 
 	<div class="prose prose-lg dark:prose-invert">
 		<section>
 			<h2>Background</h2>
 			<p>
-				Hei! I'm Kyrre, a Full Stack Developer based in Berlin with a passion for building exceptional web applications.
+				Hi! I'm Mohith, a Full Stack Developer based in Berlin with a passion for building exceptional web applications.
 				I specialize in TypeScript and Next.js, focusing on creating clean, performant solutions that address real
 				business challenges.
 			</p>

--- a/apps/portfolio/src/routes/blog/+page.svelte
+++ b/apps/portfolio/src/routes/blog/+page.svelte
@@ -6,9 +6,9 @@
 
 	let { data } = $props();
 
-	const pageTitle = 'Blog | Kyrre Gjerstad';
+	const pageTitle = 'Blog | Mohith Nagendra';
 	const description =
-		'Articles and tutorials about web development, testing, and software engineering by Kyrre Gjerstad.';
+		'Articles and tutorials about web development, testing, and software engineering by Mohith Nagendra.';
 	const canonicalUrl = 'https://kyrre.dev/blog';
 
 	// Get unique categories

--- a/apps/portfolio/src/routes/blog/[slug]/+page.svelte
+++ b/apps/portfolio/src/routes/blog/[slug]/+page.svelte
@@ -14,7 +14,7 @@
 </script>
 
 <svelte:head>
-	<title>{pageTitle} | Kyrre Gjerstad</title>
+	<title>{pageTitle} | Mohith Nagendra</title>
 	<meta name="description" content={description} />
 	<meta name="keywords" content={keywords.join(', ')} />
 	<meta name="author" content={data.meta.author} />
@@ -47,7 +47,7 @@
 			<p>
 				<time datetime={data.meta.publishedAt}>{formatDate(data.meta.publishedAt)}</time>
 				<span>by</span>
-				<a href="/about/kyrregjerstad" rel="author">{data.meta.author}</a>
+				<a href="/about/mohithnagendra" rel="author">{data.meta.author}</a>
 			</p>
 		</header>
 		<div>

--- a/apps/portfolio/src/routes/blog/[slug]/+page.ts
+++ b/apps/portfolio/src/routes/blog/[slug]/+page.ts
@@ -16,8 +16,8 @@ export const load: PageLoad = async ({ params, data }) => {
 			content: post.default,
 			meta: post.metadata,
 			socials: {
-				siteName: 'Kyrre Gjerstad | Blog',
-				title: `${post.metadata.title} | Kyrre Gjerstad`,
+				siteName: 'Mohith Nagendra | Blog',
+				title: `${post.metadata.title} | Mohith Nagendra`,
 				description: post.metadata.description,
 				image: 'https://kyrre.dev/images/og-kyrre-gjerstad-blog.jpg',
 			},

--- a/apps/portfolio/src/routes/projects/[slug]/+page.svelte
+++ b/apps/portfolio/src/routes/projects/[slug]/+page.svelte
@@ -79,7 +79,7 @@
 	<Gallery
 		images={project.images.map((image, i) => ({
 			src: image.asset?.url ?? '',
-			alt: `Kyrre Gjerstad - ${project.title} screenshot ${i + 1}`,
+			alt: `Mohith Nagendra - ${project.title} screenshot ${i + 1}`,
 			blurHash: image.asset?.metadata?.blurHash ?? '',
 		}))}
 	/>


### PR DESCRIPTION
This pull request updates the portfolio site to rebrand it from "Kyrre Gjerstad" to "Mohith Nagendra." The changes affect author names, profile links, social media, metadata, and content across the site to reflect the new identity.

**Rebranding and Identity Updates:**

* Changed all instances of the author name from "Kyrre Gjerstad" to "Mohith Nagendra" throughout the codebase, including page titles, meta tags, blog posts, and project galleries. [[1]](diffhunk://#diff-9b0e13ca1a6a3928a3d804c5e3800f0ec1172849e53efa7df3e387473b954711L12-R12) [[2]](diffhunk://#diff-91b03f4b72c0987f836fa3547c3633789e868939387e27b63f6b8da45c4ac552L9-R9) [[3]](diffhunk://#diff-9ed973ab92fe01260ce44bd37758a7bd478cc664708be28342f96f901b4c7c0aL8-R8) [[4]](diffhunk://#diff-9ed973ab92fe01260ce44bd37758a7bd478cc664708be28342f96f901b4c7c0aL22-R36) [[5]](diffhunk://#diff-8833323dc32742414de516dc4b600808561c599a3b3d9e726120dadfbc281a8eL4-R4) [[6]](diffhunk://#diff-8833323dc32742414de516dc4b600808561c599a3b3d9e726120dadfbc281a8eL18-R32) [[7]](diffhunk://#diff-140a9ab3d90dc6c46ade2bd36de1c7849e094d43337854721260e63f4f3225e7L9-R11) [apps/portfolio/src/routes/blog/[slug]/+page.svelteL17-R17](diffhunk://#diff-2480590723740b88de3721fe543cdbb6960ebe6a4bb72fe7b7e99bafe66979d4L17-R17), [apps/portfolio/src/routes/projects/[slug]/+page.svelteL82-R82](diffhunk://#diff-48664ecf7f97a2b6d88a690629f3db8a97edb2405c80aba76144d67279b9104cL82-R82), [apps/portfolio/src/routes/blog/[slug]/+page.tsL19-R20](diffhunk://#diff-cc93e8bdb47eb0d402fce6e9cd34fdf48cc24f34095f829faba8b2964ddb87adL19-R20), [[8]](diffhunk://#diff-e056367b74846ebd6de9ab748224e948f5c2f85e31c2c1e0f2dcf0d247b54c99L10-R27)
* Updated the "About" page and related references to use the new name and profile details. [[1]](diffhunk://#diff-5a35e3a3bb793a9569077a02c26444a3dc16fb46cfc3bfe1d380c3ed06911960L5-R8) [[2]](diffhunk://#diff-5a35e3a3bb793a9569077a02c26444a3dc16fb46cfc3bfe1d380c3ed06911960L18-R33)

**Social Media and Contact Links:**

* Updated all social and contact links (LinkedIn, GitHub, email) in the footer and hero sections to point to Mohith Nagendra's profiles and contact information. [[1]](diffhunk://#diff-fe7f40c96095317d151ddf967c3e0eca117a91fe68faafc7d4d0369649cd76ceL14-R30) [[2]](diffhunk://#diff-24348e24d9f39b9345b5a566b4f0fecc832e8f59c14be2bc79df319b4611b6e9L45-R45) [[3]](diffhunk://#diff-24348e24d9f39b9345b5a566b4f0fecc832e8f59c14be2bc79df319b4611b6e9L54-R54) [[4]](diffhunk://#diff-24348e24d9f39b9345b5a566b4f0fecc832e8f59c14be2bc79df319b4611b6e9L63-R63)

**Navigation and Internal Links:**

* Changed navigation links and author attributions to use the new about page and author slug (`/about/mohithnagendra`) instead of the previous one. ([apps/portfolio/src/components/Footer.svelteL40-R45](diffhunk://#diff-fe7f40c96095317d151ddf967c3e0eca117a91fe68faafc7d4d0369649cd76ceL40-R45), [apps/portfolio/src/routes/blog/[slug]/+page.svelteL50-R50](diffhunk://#diff-2480590723740b88de3721fe543cdbb6960ebe6a4bb72fe7b7e99bafe66979d4L50-R50))

**Content and Presentation:**

* Updated hero section greeting and profile alt text to reflect the new identity. [[1]](diffhunk://#diff-24348e24d9f39b9345b5a566b4f0fecc832e8f59c14be2bc79df319b4611b6e9L22-R22) [[2]](diffhunk://#diff-5a35e3a3bb793a9569077a02c26444a3dc16fb46cfc3bfe1d380c3ed06911960L18-R33)
* Modified blog and project pages to attribute content and screenshots to Mohith Nagendra. [[1]](diffhunk://#diff-140a9ab3d90dc6c46ade2bd36de1c7849e094d43337854721260e63f4f3225e7L9-R11) [[2]](diffhunk://#diff-91b03f4b72c0987f836fa3547c3633789e868939387e27b63f6b8da45c4ac552L9-R9) [apps/portfolio/src/routes/projects/[slug]/+page.svelteL82-R82](diffhunk://#diff-48664ecf7f97a2b6d88a690629f3db8a97edb2405c80aba76144d67279b9104cL82-R82))

These changes ensure the portfolio is fully rebranded for Mohith Nagendra across all user-facing and metadata elements.