### PR TITLE
(chore): bump to pnpm 10.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,5 +22,5 @@
 		"unique-names-generator": "^4.7.1",
 		"wrangler": "^4.15.2"
 	},
-	"packageManager": "pnpm@10.1.0"
+	"packageManager": "pnpm@10.22.0"
 }

--- a/turbo.json
+++ b/turbo.json
@@ -2,7 +2,7 @@
     "$schema": "https://turbo.build/schema.json",
     "tasks": {
         "build": {
-            "outputs": ["dist/**"],
+            "outputs": [".vercel/output/**"],
             "env": [
                 "PRIVATE_GITHUB_TOKEN",
                 "PRIVATE_MAILJET_API_KEY",


### PR DESCRIPTION
This pull request contains minor updates to project configuration files to improve compatibility with deployment and package management tools.

- Tooling and deployment configuration:
  * Updated the `build` task in `turbo.json` to output to `.vercel/output/**` instead of `dist/**`, aligning with Vercel's deployment requirements.

- Package management:
  * Upgraded the `pnpm` version in `package.json` from `10.1.0` to `10.22.0` for improved package management and compatibility.