### PR TITLE
(fix): contact navigation so it's not hidden

### DIFF
--- a/apps/portfolio/src/components/Divider.svelte
+++ b/apps/portfolio/src/components/Divider.svelte
@@ -7,8 +7,9 @@
 		class?: string;
 		duration?: number;
 		delay?: number;
+		id?: string;
 	};
-	const { class: className, duration = 2000, delay = 0 }: Props = $props();
+	const { class: className, duration = 2000, delay = 0, id }: Props = $props();
 
 	let mounted = $state(false);
 
@@ -17,7 +18,7 @@
 	});
 </script>
 
-<div class={cn('my-8 h-1 sm:my-12', className)}>
+<div id={id} class={cn('my-8 h-1 sm:my-12', className)}>
 	{#if mounted}
 		<svg class="stroke-muted-foreground text-muted-foreground opactity-50 h-1 w-full">
 			<line

--- a/apps/portfolio/src/components/Navbar.svelte
+++ b/apps/portfolio/src/components/Navbar.svelte
@@ -8,7 +8,7 @@
 	import { Menu } from 'lucide-svelte';
 	let open = false;
 
-    $: navClasses = `flex justify-start md:justify-center ${$page.url.pathname === '/' ? 'pb-8' : 'pb-0'} md:pb-0`;
+    $: navClasses = `flex justify-start md:justify-center md:pb-0`;
 </script>
 
 <nav class="{navClasses}">

--- a/apps/portfolio/src/routes/+layout.svelte
+++ b/apps/portfolio/src/routes/+layout.svelte
@@ -28,7 +28,7 @@
 <Analytics />
 <SEO {...data.SEO} />
 <Socials />
-<PageTransition />
+<!-- <PageTransition /> -->
 <div class="relative overflow-hidden">
 	<Border>
 		<main class="no-scrollbar relative flex flex-col p-10 sm:p-16">

--- a/apps/portfolio/src/routes/+page.svelte
+++ b/apps/portfolio/src/routes/+page.svelte
@@ -40,8 +40,8 @@
 			<h2 class="pb-4 text-3xl font-bold">Experiments</h2>
 			<List items={experiments} />
 		</section>
-		<Divider />
-		<section id="contact">
+		<Divider id="contact" />
+		<section>
 			<h2 class="pb-4 text-3xl font-bold">Contact</h2>
 			<ContactForm {contactForm} />
 		</section>


### PR DESCRIPTION
This pull request introduces a few small but notable updates to the portfolio app, mainly focusing on improving accessibility and navigation, as well as making minor UI adjustments. The most significant change is the addition of an optional id prop to the Divider component, which enables better in-page navigation.

Component enhancements:

* Added an optional `id` prop to the `Divider` component (`Divider.svelte`) to allow for anchor-based navigation and improved accessibility. [[1]](diffhunk://#diff-068990364bb1d5b7481edce80be947b6a797b7bccc166d027b13cebecceb4bc8R10-R12) [[2]](diffhunk://#diff-068990364bb1d5b7481edce80be947b6a797b7bccc166d027b13cebecceb4bc8L20-R21)
* Updated the homepage to use the new `id` prop on the `Divider` before the Contact section, enabling direct linking to the contact area.

UI and layout adjustments:

* Removed conditional bottom padding from the navbar for consistency across pages (`Navbar.svelte`).
* Commented out the `PageTransition` component in the layout, possibly to disable page transitions temporarily.