### PR TITLE
(fix): get rid of web and cli placecard

### DIFF
--- a/apps/portfolio/src/projects/2024-crime-in-los-angeles-analysis.md
+++ b/apps/portfolio/src/projects/2024-crime-in-los-angeles-analysis.md
@@ -4,7 +4,7 @@ slug: '2024-crime-in-los-angeles-analysis'
 description: 'An analysis of 2024 Los Angeles crime data to uncover trends, predict victim demographics using machine learning, and identify high-risk areas to inform safety strategies.'
 href: 'https://mohithbuilds.github.io/'
 linkTitle: 'View on GitHub'
-gitHubLink: 'https://github.com/mohithbuilds/mohithbuilds.github.io.git'
+gitHubLink: 'https://github.com/mohithbuilds/mohithbuilds.github.io'
 client: 'Personal'
 type: 'web'
 keyFeatures:

--- a/apps/portfolio/src/projects/2024-crime-in-los-angeles-analysis.md
+++ b/apps/portfolio/src/projects/2024-crime-in-los-angeles-analysis.md
@@ -4,7 +4,7 @@ slug: '2024-crime-in-los-angeles-analysis'
 description: 'An analysis of 2024 Los Angeles crime data to uncover trends, predict victim demographics using machine learning, and identify high-risk areas to inform safety strategies.'
 href: 'https://mohithbuilds.github.io/'
 linkTitle: 'View on GitHub'
-gitHubLink: 'https://mohithbuilds.github.io/'
+gitHubLink: 'https://github.com/mohithbuilds/mohithbuilds.github.io.git'
 client: 'Personal'
 type: 'web'
 keyFeatures:

--- a/apps/portfolio/src/routes/projects/+page.svelte
+++ b/apps/portfolio/src/routes/projects/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { Card, CardDescription, CardHeader, CardTitle } from '$lib/components/ui/card';
-	import ProjectTypeChip from '@/components/ProjectTypeChip.svelte';
+
 
 	let { data } = $props();
 
@@ -40,9 +40,7 @@
 									{project.title}
 								</a>
 							</CardTitle>
-							{#if project.type}
-								<ProjectTypeChip type={project.type} />
-							{/if}
+
 						</div>
 						{#if project.description}
 							<CardDescription class="line-clamp-2">{project.description}</CardDescription>

--- a/apps/portfolio/src/routes/projects/[slug]/+page.svelte
+++ b/apps/portfolio/src/routes/projects/[slug]/+page.svelte
@@ -6,7 +6,7 @@
 	import { ExternalLinkIcon, GithubIcon, X } from '@lucide/svelte';
 
 	import Divider from '@/components/Divider.svelte';
-	import ProjectTypeChip from '@/components/ProjectTypeChip.svelte';
+
 	import { scrollToTop } from '@/lib/utils';
 	import AnimatedCounter from '@/routes/AnimatedCounter.svelte';
 
@@ -35,9 +35,7 @@
 	<div>
 		<h2 class="text-md pb-2">Meta:</h2>
 		<div class="flex flex-wrap gap-2">
-			{#if project.type}
-				<ProjectTypeChip type={project.type} />
-			{/if}
+
 			{#if project.gitHubLink}
 				<LinkButton href={project.gitHubLink}>
 					<GithubIcon class="size-4 sm:size-6" />


### PR DESCRIPTION
This pull request primarily removes the display of the `ProjectTypeChip` component from both the project list and project detail pages, simplifying the project metadata presentation. Additionally, it corrects the `gitHubLink` URL in the 2024 Los Angeles crime analysis project metadata to point to the actual GitHub repository.

**Project metadata and UI simplification:**

* Removed the `ProjectTypeChip` component from the project cards in the project list (`+page.svelte`) and from the project meta section in the project detail page (`[slug]/+page.svelte`). [[1]](diffhunk://#diff-b4d06b7e7acfd1a5a563beab31000a9e612e0c53ba73874e3e0ab88cf4ba22e4L3-R3) [[2]](diffhunk://#diff-b4d06b7e7acfd1a5a563beab31000a9e612e0c53ba73874e3e0ab88cf4ba22e4L43-R43) [apps/portfolio/src/routes/projects/[slug]/+page.svelteL9-R9](diffhunk://#diff-48664ecf7f97a2b6d88a690629f3db8a97edb2405c80aba76144d67279b9104cL9-R9), [apps/portfolio/src/routes/projects/[slug]/+page.svelteL38-R38](diffhunk://#diff-48664ecf7f97a2b6d88a690629f3db8a97edb2405c80aba76144d67279b9104cL38-R38))

**Metadata correction:**

* Updated the `gitHubLink` for the 2024 Los Angeles crime analysis project to reference the correct GitHub repository URL.